### PR TITLE
Ignore generated sample_data-*.csv files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ignore generated sample_data files
+sample_data-*.csv
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
When using the tools on the included `sample_data.csv`, they output a file named `sample_data-*.csv` (where `*` depends on the tool used).  This PR adds these generated files to the `.gitignore`.